### PR TITLE
Update bun Runtimes. add bun 1.1 runtime.

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -105,6 +105,7 @@ class Runtimes
 
         $bun = new Runtime('bun', 'Bun', 'bun src/server.ts');
         $bun->addVersion('1.0', 'oven/bun:1.0.29', 'openruntimes/bun:'.$this->version.'-1.0', [System::X86, System::ARM64]);
+        $bun->addVersion('1.1', 'oven/bun:1.1.18', 'openruntimes/bun:'.$this->version.'-1.1', [System::X86, System::ARM64]);
         $this->runtimes['bun'] = $bun;
 
         $go = new Runtime('go', 'Go', 'src/function/server');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This pr add bun 1.1 runtime for the appwrite backend, for the frontend, see also https://github.com/appwrite/sdk-for-console/issues/13.

## Test Plan

1. Build `openruntimes/bun:v3-1.1` image, see also https://github.com/open-runtimes/open-runtimes/issues/277.
2. Update the backend and frontend of appwrite.
3. Update the cloud function runtime to use bun-1.1

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)