### PR TITLE
Chore: Remove swift 5.5

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -92,7 +92,6 @@ class Runtimes
         $this->runtimes['java'] = $java;
 
         $swift = new Runtime('swift', 'Swift', 'sh helpers/server.sh');
-        $swift->addVersion('5.5', 'swiftarm/swift:5.5.3-ubuntu-jammy', 'openruntimes/swift:'.$this->version.'-5.5', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $swift->addVersion('5.8', 'swiftarm/swift:5.8.1-ubuntu-22.04', 'openruntimes/swift:'.$this->version.'-5.8', [System::X86, System::ARM64, System::ARMV7, System::ARMV8]);
         $swift->addVersion('5.9', 'swiftarm/swift:5.9.2-ubuntu-22.04', 'openruntimes/swift:'.$this->version.'-5.9', [System::X86, System::ARM64,  System::ARMV7, System::ARMV8]);
         $swift->addVersion('5.10', 'swiftarm/swift:5.10-ubuntu-22.04', 'openruntimes/swift:'.$this->version.'-5.10', [System::X86, System::ARM64,  System::ARMV7, System::ARMV8]);

--- a/tests/Runtimes/RuntimesTest.php
+++ b/tests/Runtimes/RuntimesTest.php
@@ -134,12 +134,6 @@ class RuntimesTest extends TestCase
                 'timeout' => 15,
                 'runtime' => 'java-18.0',
             ],
-            'swift-5.5' => [
-                'code' => $functionsDir.'/swift.tar.gz',
-                'command' => './helloworld',
-                'timeout' => 15,
-                'runtime' => 'swift-5.5',
-            ],
             'kotlin-1.6' => [
                 'code' => $functionsDir.'/kotlin.tar.gz',
                 'command' => 'kotlin HelloWorld',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

SwiftARM we used to use is no longer maintained. Official Swift has ARM support, but only since Swift 5.6.

Due to that, and the age of swift 5.5, we are removing support for it in future Appwrite releases

## Test Plan

Tests updated

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes