### PR TITLE
feat(runtimes): add bun 1.2.15

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -136,6 +136,7 @@ class Runtimes
         $bun = new Runtime('bun', 'Bun', 'bash helpers/server.sh');
         $bun->addVersion('1.0', 'oven/bun:1.0.36-alpine', 'openruntimes/bun:'.$this->version.'-1.0', [System::X86, System::ARM64]);
         $bun->addVersion('1.1', 'oven/bun:1.1.29-alpine', 'openruntimes/bun:'.$this->version.'-1.1', [System::X86, System::ARM64]);
+        $bun->addVersion('1.2', 'oven/bun:1.2.15-alpine', 'openruntimes/bun:'.$this->version.'-1.2', [System::X86, System::ARM64]);
         $this->runtimes['bun'] = $bun;
 
         $go = new Runtime('go', 'Go', 'bash helpers/server.sh');


### PR DESCRIPTION
## What does this PR do?

Upgrades Bun runtime to Bun 1.2.15

## Test Plan

Tested inside openruntimes repository, verified the JSX runtime issues don't exist. It was fixed in Bun https://github.com/oven-sh/bun/issues/3768

## Related PRs and Issues

https://github.com/oven-sh/bun/issues/3768

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes