### PR TITLE
feat: add Bun 1.4 runtime

### DIFF
--- a/src/Runtimes/Runtimes.php
+++ b/src/Runtimes/Runtimes.php
@@ -159,6 +159,7 @@ class Runtimes
         $bun->addVersion('1.1', 'oven/bun:1.1.29-alpine', 'openruntimes/bun:'.$this->version.'-1.1', [System::X86, System::ARM64]);
         $bun->addVersion('1.2', 'oven/bun:1.2.23-alpine', 'openruntimes/bun:'.$this->version.'-1.2', [System::X86, System::ARM64]);
         $bun->addVersion('1.3', 'oven/bun:1.3.8-alpine', 'openruntimes/bun:'.$this->version.'-1.3', [System::X86, System::ARM64]);
+        $bun->addVersion('1.4', 'oven/bun:1.4.0-alpine', 'openruntimes/bun:'.$this->version.'-1.4', [System::X86, System::ARM64]);
         $this->runtimes['bun'] = $bun;
 
         $go = new Runtime('go', 'Go', 'bash helpers/server.sh');


### PR DESCRIPTION
## Summary
- Register Bun 1.4 (`oven/bun:1.4.0-alpine` → `openruntimes/bun:v5-1.4`)

Published in open-runtimes 0.13.23 (open-runtimes/open-runtimes#551). Image is live on Docker Hub with both `amd64` and `arm64`.

Bun 1.4 brings Node.js 26.3.0 compatibility, parallel test/run, and Windows ARM64 — https://bun.com/blog/bun-v1.4

## Test plan
- [x] `vendor/bin/phpunit` — 11 tests, 1148 assertions, green
- [x] `bun-1.4` resolves to `openruntimes/bun:v5-1.4`
- [x] Docker Hub manifest asserts `amd64,arm64`