### PR TITLE
fix: allow System 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "utopia-php/system": "0.10.*"
+        "utopia-php/system": "^0.10 || ^0.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c4a6173d0b14e44c4db52fbf5344179",
+    "content-hash": "9ca88ea16a6bf63b0cc0f06465cbd751",
     "packages": [
         {
             "name": "utopia-php/system",
-            "version": "0.10.0",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/system.git",
-                "reference": "6441a9c180958a373e5ddb330264dd638539dfdb"
+                "reference": "f7077643de7e012945f6e3fc4c3c36e7f1d40047"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/system/zipball/6441a9c180958a373e5ddb330264dd638539dfdb",
-                "reference": "6441a9c180958a373e5ddb330264dd638539dfdb",
+                "url": "https://api.github.com/repos/utopia-php/system/zipball/f7077643de7e012945f6e3fc4c3c36e7f1d40047",
+                "reference": "f7077643de7e012945f6e3fc4c3c36e7f1d40047",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0.0"
-            },
-            "require-dev": {
-                "laravel/pint": "1.13.*",
-                "phpstan/phpstan": "1.12.*",
-                "phpunit/phpunit": "9.6.*"
             },
             "type": "library",
             "autoload": {
@@ -58,9 +53,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/system/issues",
-                "source": "https://github.com/utopia-php/system/tree/0.10.0"
+                "source": "https://github.com/utopia-php/system/tree/0.11.0"
             },
-            "time": "2025-10-15T19:12:00+00:00"
+            "time": "2026-09-07T09:56:23+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Allow consumers to require System 0.11 directly. The current `0.10.*` constraint prevents Cloud from adopting System's new cgroup-aware memory capacity API without an alias.

Accept `^0.10 || ^0.11`, preserving compatibility with existing consumers, and update the development lockfile to System 0.11.0. No runtime code changes.

Validation: Composer resolves the lockfile with only System updated (`--no-install --no-scripts --ignore-platform-reqs` on macOS). The runtime test suite was not rerun. After merge, publish a patch release so appwrite-labs/cloud#5687 can use System 0.11 directly.
